### PR TITLE
fix: Correct version extraction in release workflow to include version formatting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get latest changelog entry
         id: changelog
         run: |
-          VERSION=$(grep -m1 '^## ' $CHANGELOG_FILE | sed 's/^## //')
+          VERSION=$(grep -m1 '^## ' $CHANGELOG_FILE | sed -E 's/^## \[([^\]]+)\].*/v\1/')
           BODY=$(awk '/^## /{i++}i==2{exit}i==1' $CHANGELOG_FILE | tail -n +2)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "body<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request updates the version extraction logic in the release workflow to include a "v" prefix and handle changelog entries with square brackets.

Workflow improvements:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L24-R24): Modified the `VERSION` extraction command to use a regular expression that captures the version inside square brackets and prefixes it with "v" (e.g., `[1.2.3]` becomes `v1.2.3`).