### PR TITLE
fix: Correct regex for version extraction in release workflow to match semantic versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get latest changelog entry
         id: changelog
         run: |
-          VERSION=$(grep -m1 '^## ' $CHANGELOG_FILE | sed -E 's/^## \[([^\]]+)\].*/v\1/')
+          VERSION=$(grep -m1 '^## ' $CHANGELOG_FILE | sed -E 's/^## \[([0-9.]+)\].*/v\1/')
           BODY=$(awk '/^## /{i++}i==2{exit}i==1' $CHANGELOG_FILE | tail -n +2)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "body<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
…h semantic versioning
This pull request updates the version extraction logic in the release workflow to ensure it only matches numeric version patterns in the changelog.

Workflow improvement:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L24-R24): Updated the `sed` command in the `Get latest changelog entry` step to match only numeric version patterns (e.g., `1.2.3`) instead of any text within square brackets.