### PR TITLE
ci: add GitHub workflow to auto-create releases from changelog entries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,14 @@ jobs:
         run: |
           export LC_ALL=C.UTF-8
           export LANG=C.UTF-8
-          VERSION=$(grep -m1 '^## ' $CHANGELOG_FILE | sed -E 's/^## \[([0-9.]+)\].*/v\1/')
-          BODY=$(awk '/^## /{i++}i==2{exit}i==1' $CHANGELOG_FILE | tail -n +2)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          echo "$BODY" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          VERSION=$(grep -m1 '^## ' "$CHANGELOG_FILE" | sed -E 's/^## \[([0-9.]+)\].*/v\1/')
+          BODY=$(awk '/^## /{i++}i==2{exit}i==1' "$CHANGELOG_FILE" | tail -n +2)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          {
+            echo "body<<EOF"
+            echo "$BODY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
This pull request refactors the way environment variables and outputs are handled in the `release.yml` workflow file to improve readability and ensure proper quoting.

### Workflow improvements:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L26-R33): Updated shell commands to properly quote variables like `$CHANGELOG_FILE` and `$GITHUB_OUTPUT`, and replaced multiple `echo` statements with a block using curly braces for better readability and maintainability.